### PR TITLE
Add generation notice card to guide generation screen

### DIFF
--- a/mobile/app/(tabs)/home/generate.tsx
+++ b/mobile/app/(tabs)/home/generate.tsx
@@ -223,6 +223,19 @@ export default function GenerateScreen() {
     return !(step?.image_url || stepImages[key]);
   });
 
+  const GenerationNotice = () => (
+    <View
+      style={[
+        styles.noticeCard,
+        { backgroundColor: colors.cardBackground },
+      ]}
+    >
+      <Typography variant="body" color={colors.secondaryText}>
+        It might take a few minutes to generate everything completely.
+      </Typography>
+    </View>
+  );
+
   if (!object && !error) {
     return (
       <View
@@ -230,6 +243,7 @@ export default function GenerateScreen() {
           styles.loadingContainer
         ]}
       >
+        <GenerationNotice />
         <ActivityIndicator size="large" color={colors.tint} />
         <Typography variant="body" color={colors.secondaryText}>
           Generating You Guide...
@@ -240,6 +254,7 @@ export default function GenerateScreen() {
 
   return (
     <ScrollPageContainer header>
+      <GenerationNotice />
       {/* Guide Header Section */}
       {object && (
         <View style={styles.section}>
@@ -349,6 +364,13 @@ const styles = StyleSheet.create({
     alignItems: "center",
     gap: 16,
 
+  },
+  noticeCard: {
+    alignSelf: "stretch",
+    marginHorizontal: 16,
+    marginBottom: 16,
+    padding: 16,
+    borderRadius: 12,
   },
   section: {
     gap: 16,


### PR DESCRIPTION
## Summary
- show a message on the home generate page letting users know full generation may take a few minutes
- reuse the notice in both the loading state and the main content using the themed card background color

## Testing
- npm test -- --watchAll=false --passWithNoTests

------
https://chatgpt.com/codex/tasks/task_e_68cc9e3bba0483248c415a98aff7cc21